### PR TITLE
Fix slide width and horizontal scrolling on iOS

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -43,15 +43,14 @@ body{
   display:flex; gap:20px;
   overflow-x:auto; overscroll-behavior-x:contain;
   scroll-snap-type:x mandatory;
-  padding:16px;
-  touch-action: pan-y;
+  padding:16px 0;
+  touch-action:pan-x pan-y;
+  -webkit-overflow-scrolling:touch;
 }
 .slide{
   scroll-snap-align:start;
   flex:0 0 100%;
-  max-width:680px;
-  margin:0 auto;
-  padding-bottom:64px;
+  padding:0 16px 64px;
 }
 h1{font-size:20px; margin:8px 4px 16px}
 h2{font-size:16px; margin:0 0 12px}


### PR DESCRIPTION
## Summary
- ensure each slide spans the full viewport width on mobile
- allow touch horizontal scrolling and momentum on iOS

## Testing
- `npm test` (fails: Could not read package.json: ENOENT)


------
https://chatgpt.com/codex/tasks/task_e_68a397837d3c8322a545f234eaa79929