### PR TITLE
Support des commandes iOS pour le lecteur

### DIFF
--- a/app.js
+++ b/app.js
@@ -300,8 +300,12 @@
   });
   audio.addEventListener('pause', ()=>{
     playPause.textContent = 'Lecture';
+    setMediaSession();
   });
-  audio.addEventListener('ended', ()=>{ playPause.textContent = 'Lecture'; });
+  audio.addEventListener('ended', ()=>{ 
+    playPause.textContent = 'Lecture';
+    setMediaSession();
+  });
 
   audio.addEventListener('error', ()=>{
     // Erreur potentielle de “mixed content” ou CORS
@@ -358,6 +362,8 @@
     if (!('mediaSession' in navigator)) return;
     const cur = getCurrent();
     if (!cur) return;
+
+    navigator.mediaSession.playbackState = audio.paused ? 'paused' : 'playing';
 
     if (settings.showLockInfo){
       navigator.mediaSession.metadata = new MediaMetadata({


### PR DESCRIPTION
## Résumé
- Met à jour `MediaSession` pour refléter l'état lecture/pause.
- Actualise la session lors des événements `pause` et `ended`.

## Tests
- `npm test` (échec : fichier `package.json` introuvable).

------
https://chatgpt.com/codex/tasks/task_e_68a42bd62ad883228cc530772c80aeb1