### PR TITLE
Ajout du bouton Coller et amélioration de la détection des flux

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,6 +25,7 @@
   const fId = $('#streamId');
   const fName = $('#streamName');
   const fUrl = $('#streamUrl');
+  const pasteUrl = $('#pasteUrl');
   const fFmt = $('#streamFormat');
   const fFav = $('#streamFav');
   const fNotes = $('#streamNotes');
@@ -103,12 +104,21 @@
   async function checkClipboard(){
     if (!navigator.clipboard) return;
     try {
-      const text = await navigator.clipboard.readText();
+      let text = await navigator.clipboard.readText();
+      text = text.trim();
       if (text && /^https?:\/\/\S+/i.test(text) && !fUrl.value) {
-        fUrl.value = text.trim();
+        fUrl.value = text;
       }
     } catch {}
   }
+
+  pasteUrl?.addEventListener('click', async ()=>{
+    if (!navigator.clipboard) return;
+    try{
+      const text = (await navigator.clipboard.readText()).trim();
+      if (text) fUrl.value = text;
+    }catch{}
+  });
 
   // ------- Haptics (soft) -------
   function buzz(){

--- a/index.html
+++ b/index.html
@@ -86,7 +86,10 @@
             <input id="streamName" type="text" placeholder="ex. FIP hifi" required />
           </label>
           <label>URL
-            <input id="streamUrl" type="url" placeholder="http(s)://..." required />
+            <div class="row url-row">
+              <input id="streamUrl" type="url" placeholder="http(s)://..." required />
+              <button type="button" id="pasteUrl" class="btn small">Coller</button>
+            </div>
           </label>
           <label>Format (optionnel)
             <select id="streamFormat">

--- a/styles.css
+++ b/styles.css
@@ -66,6 +66,7 @@ h2{font-size:16px; margin:0 0 12px}
 }
 .grid label{display:flex; flex-direction:column; gap:6px}
 .grid .row{grid-column:1/-1}
+.url-row input{flex:1}
 
 label input[type="text"], label input[type="url"], label select, input[type="number"]{
   padding:12px; border:1px solid var(--border); border-radius:12px; background:#fff; font-size:16px;


### PR DESCRIPTION
## Résumé
- Corrige la détection automatique des URL copiées en nettoyant le texte du presse-papiers
- Ajoute un bouton "Coller" à côté du champ URL pour insérer le presse-papiers
- Ajuste la mise en page du formulaire pour accueillir le bouton

## Tests
- `npm test` *(échec : package.json manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68a55f3d5cbc8322a93706e0f1ccb4e0