### PR TITLE
Affichage d'informations de morceau avec journal

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,32 +37,38 @@
     <section class="slide" aria-labelledby="player-title">
       <h1 id="player-title">Lecteur</h1>
 
-      <div class="player-card card">
-        <div class="now-meta">
-          <div class="title" id="nowName">Aucun flux</div>
-          <div class="url" id="nowUrl">—</div>
-          <div class="meta muted" id="nowMeta"></div>
-        </div>
-
-        <audio id="audio" preload="none" playsinline></audio>
-
-        <div class="controls">
-          <button id="playPause" class="btn primary" disabled aria-label="Lecture">▶︎</button>
-          <label class="vol">
-            Volume
-            <input id="volume" type="range" min="0" max="1" step="0.01" value="1" />
-          </label>
-        </div>
-
-        <div class="extras">
-          <label class="mui-switch"><input type="checkbox" id="autoResume"> Reprendre automatiquement le dernier flux</label>
-          <label class="mui-switch"><input type="checkbox" id="showLockInfo"> Afficher titre sur l’écran verrouillé</label>
-          <div class="sleep">
-            Minuteur sommeil (min) :
-            <input id="sleepMinutes" type="number" min="0" max="240" step="5" value="0" />
-            <button id="sleepStart" class="btn">Démarrer</button>
-            <span id="sleepLeft" class="muted"></span>
+      <div class="player-area">
+        <div class="player-card card">
+          <div class="now-meta">
+            <div class="title" id="nowName">Aucun flux</div>
+            <div class="url" id="nowUrl">—</div>
+            <div class="meta muted" id="nowMeta"></div>
           </div>
+
+          <audio id="audio" preload="none" playsinline></audio>
+
+          <div class="controls">
+            <button id="playPause" class="btn primary" disabled aria-label="Lecture">▶︎</button>
+            <label class="vol">
+              Volume
+              <input id="volume" type="range" min="0" max="1" step="0.01" value="1" />
+            </label>
+          </div>
+
+          <div class="extras">
+            <label class="mui-switch"><input type="checkbox" id="autoResume"> Reprendre automatiquement le dernier flux</label>
+            <label class="mui-switch"><input type="checkbox" id="showLockInfo"> Afficher titre sur l’écran verrouillé</label>
+            <div class="sleep">
+              Minuteur sommeil (min) :
+              <input id="sleepMinutes" type="number" min="0" max="240" step="5" value="0" />
+              <button id="sleepStart" class="btn">Démarrer</button>
+              <span id="sleepLeft" class="muted"></span>
+            </div>
+          </div>
+        </div>
+        <div id="logBox" class="card log-box">
+          <h2>Journal</h2>
+          <div id="logEntries" class="log-entries"></div>
         </div>
       </div>
 

--- a/styles.css
+++ b/styles.css
@@ -119,6 +119,12 @@ label input[type="text"], label input[type="url"], label select, input[type="num
 .vol{display:flex; align-items:center; gap:10px}
 .muted{color:var(--muted); font-size:12px}
 
+.player-area{display:flex; gap:16px; flex-wrap:wrap}
+.player-area .player-card{flex:1 1 300px}
+.log-box{flex:1 1 200px; font-size:12px; max-height:150px; overflow:auto}
+.log-box h2{margin:0 0 8px; font-size:14px}
+.log-entries{display:flex; flex-direction:column; gap:4px}
+
 .stream-list, .manage-list{
   list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:8px;
 }


### PR DESCRIPTION
## Résumé
- afficher les métadonnées du morceau courant
- indiquer l'absence d'informations ou les erreurs
- ajouter une fenêtre de journal en français

## Test
- `npm test` *(échoue : Missing script: "test")*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5d398bbc88322ad4e08e82ca5d4b1