### PR TITLE
Ajout de fallback Icecast pour les métadonnées

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,6 +11,44 @@ app.use(cors());
 app.use(express.json());
 app.use(express.static(__dirname));
 
+async function fetchFallback(streamUrl) {
+  try {
+    const { origin } = new URL(streamUrl);
+
+    // Icecast JSON status
+    try {
+      const res = await fetch(`${origin}/status-json.xsl`, {
+        headers: { 'User-Agent': 'Node-ICY' }
+      });
+      const data = await res.json();
+      const source = Array.isArray(data?.icestats?.source)
+        ? data.icestats.source[0]
+        : data?.icestats?.source;
+      if (source?.title) {
+        return { StreamTitle: source.title };
+      }
+    } catch {}
+
+    // Generic "now playing" API
+    try {
+      const res = await fetch(`${origin}/nowplaying`, {
+        headers: { 'User-Agent': 'Node-ICY' }
+      });
+      const data = await res.json();
+      const title =
+        data?.now_playing?.song?.text ||
+        data?.now_playing?.song?.title ||
+        data?.song ||
+        data?.title;
+      if (title) {
+        return { StreamTitle: title };
+      }
+    } catch {}
+  } catch {}
+
+  return {};
+}
+
 async function readStreams() {
   try {
     const data = await fs.readFile(STREAM_FILE, 'utf8');
@@ -42,32 +80,41 @@ app.get('/api/metadata', (req, res) => {
   const url = req.query.url;
   if (!url) return res.status(400).json({ error: 'URL manquante' });
 
+  let answered = false;
+  const reply = data => {
+    if (answered) return;
+    answered = true;
+    res.json(data);
+  };
+
+  const sendFallback = () => {
+    fetchFallback(url).then(reply);
+  };
+
   try {
-    icy.get(url, icyRes => {
-      let answered = false;
-      icyRes.on('metadata', metadata => {
-        if (answered) return;
-        answered = true;
-        const parsed = icy.parse(metadata);
-        res.json(parsed);
-        icyRes.destroy();
-      });
-      icyRes.on('error', err => {
-        if (answered) return;
-        answered = true;
-        res.status(500).json({ error: err.message });
-      });
-      setTimeout(() => {
-        if (answered) return;
-        answered = true;
-        res.json({});
-        icyRes.destroy();
-      }, 5000);
-    }).on('error', err => {
-      res.status(500).json({ error: err.message });
+    icy.get(
+      url,
+      { headers: { 'Icy-MetaData': '1', 'User-Agent': 'Node-ICY' } },
+      icyRes => {
+        icyRes.on('metadata', metadata => {
+          const parsed = icy.parse(metadata);
+          reply(parsed);
+          icyRes.destroy();
+        });
+        icyRes.on('error', () => {
+          icyRes.destroy();
+          sendFallback();
+        });
+        setTimeout(() => {
+          icyRes.destroy();
+          sendFallback();
+        }, 5000);
+      }
+    ).on('error', () => {
+      sendFallback();
     });
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    sendFallback();
   }
 });
 


### PR DESCRIPTION
## Résumé
- ajout d'une fonction de secours pour lire les métadonnées via `/status-json.xsl` ou une API `nowplaying`
- envoi d'en-têtes `Icy-MetaData` et `User-Agent` lors des requêtes ICY

## Tests
- `npm test` *(échoue : Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d97820e88322a96b5c57eb38ae4a