### PR TITLE
Ajouter un bouton pour afficher/masquer le journal

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,7 @@
   const showLockInfo = $('#showLockInfo');
   const logBox = $('#logBox');
   const logEntries = $('#logEntries');
+  const toggleLog = $('#toggleLog');
 
   const streamList = $('#streamList');
   const addQuick = $('#addQuick');
@@ -80,6 +81,11 @@
   compactList.checked = !!settings.compactList;
   haptics.checked = !!settings.haptics;
   document.body.classList.toggle('compact', settings.compactList);
+
+  toggleLog.addEventListener('click', () => {
+    logBox.hidden = !logBox.hidden;
+    toggleLog.textContent = logBox.hidden ? 'Afficher le journal' : 'Masquer le journal';
+  });
 
   function addLog(msg, obj){
     const time = new Date().toLocaleTimeString();

--- a/index.html
+++ b/index.html
@@ -66,7 +66,8 @@
             </div>
           </div>
         </div>
-        <div id="logBox" class="card log-box">
+        <button id="toggleLog" class="btn small">Afficher le journal</button>
+        <div id="logBox" class="card log-box" hidden>
           <h2>Journal</h2>
           <div id="logEntries" class="log-entries"></div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -121,8 +121,9 @@ label input[type="text"], label input[type="url"], label select, input[type="num
 
 .player-area{display:flex; gap:16px; flex-wrap:wrap}
 .player-area .player-card{flex:1 1 300px}
-.log-box{flex:1 1 200px; font-size:12px; max-height:150px; overflow:auto}
+.log-box{flex:1 1 200px; font-size:12px; max-height:150px; overflow:auto; overflow-wrap:anywhere}
 .log-box h2{margin:0 0 8px; font-size:14px}
+.log-box pre{white-space:pre-wrap}
 .log-entries{display:flex; flex-direction:column; gap:4px}
 
 .stream-list, .manage-list{


### PR DESCRIPTION
## Résumé
- Ajout d’un bouton pour afficher ou cacher le journal des connexions
- Forçage du retour à la ligne dans le journal afin d’éviter l’élargissement du panneau

## Tests
- `npm test` (script manquant)


------
https://chatgpt.com/codex/tasks/task_e_68a60b72ac78832288a5d43c69006863