### PR TITLE
Refonte du lecteur: pastille journal et réglette sommeil

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,7 +14,6 @@
   const nowUrl = $('#nowUrl');
   const nowMeta = $('#nowMeta');
   const playPause = $('#playPause');
-  const volume = $('#volume');
   const autoResume = $('#autoResume');
   const showLockInfo = $('#showLockInfo');
   const logBox = $('#logBox');
@@ -48,7 +47,6 @@
   const appVersion = $('#appVersion');
 
   const sleepMinutes = $('#sleepMinutes');
-  const sleepStart = $('#sleepStart');
   const sleepLeft = $('#sleepLeft');
 
   const linkIcon = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>`;
@@ -84,7 +82,8 @@
 
   toggleLog.addEventListener('click', () => {
     logBox.hidden = !logBox.hidden;
-    toggleLog.textContent = logBox.hidden ? 'Afficher le journal' : 'Masquer le journal';
+    toggleLog.classList.toggle('on', !logBox.hidden);
+    toggleLog.setAttribute('aria-label', logBox.hidden ? 'Afficher le journal' : 'Masquer le journal');
   });
 
   function addLog(msg, obj){
@@ -446,7 +445,6 @@
   function safeJSON(s){ try{ return JSON.parse(s); }catch{ return null; } }
 
   // ------- Audio / Playback -------
-  volume.addEventListener('input', ()=> audio.volume = Number(volume.value));
 
   playPause.addEventListener('click', ()=>{
     if (audio.paused){
@@ -571,11 +569,11 @@
   }
 
   // ------- Sleep timer -------
-  sleepStart.addEventListener('click', ()=>{
+  sleepMinutes.addEventListener('input', ()=>{
     const mins = Math.max(0, Number(sleepMinutes.value||0));
     if (sleepTimer){ clearInterval(sleepTimer); sleepTimer = null; }
     if (mins===0){
-      sleepLeft.textContent = 'Minuteur désactivé.';
+      sleepLeft.textContent = '';
       return;
     }
     sleepETA = Date.now() + mins*60*1000;

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
 
       <div class="player-area">
         <div class="player-card card">
+          <button id="toggleLog" class="log-badge" aria-label="Afficher le journal"></button>
           <div class="now-meta">
             <div class="title" id="nowName">Aucun flux</div>
             <div class="url" id="nowUrl">—</div>
@@ -49,24 +50,27 @@
 
           <div class="controls">
             <button id="playPause" class="btn primary" disabled aria-label="Lecture">▶︎</button>
-            <label class="vol">
-              Volume
-              <input id="volume" type="range" min="0" max="1" step="0.01" value="1" />
-            </label>
           </div>
 
           <div class="extras">
             <label class="mui-switch"><input type="checkbox" id="autoResume"> Reprendre automatiquement le dernier flux</label>
             <label class="mui-switch"><input type="checkbox" id="showLockInfo"> Afficher titre sur l’écran verrouillé</label>
             <div class="sleep">
-              Minuteur sommeil (min) :
-              <input id="sleepMinutes" type="number" min="0" max="240" step="5" value="0" />
-              <button id="sleepStart" class="btn">Démarrer</button>
+              <label for="sleepMinutes">Sleep</label>
+              <input id="sleepMinutes" type="range" min="0" max="90" step="5" value="0" list="sleepMarks" />
+              <datalist id="sleepMarks">
+                <option value="0"></option>
+                <option value="15"></option>
+                <option value="30"></option>
+                <option value="45"></option>
+                <option value="60"></option>
+                <option value="75"></option>
+                <option value="90"></option>
+              </datalist>
               <span id="sleepLeft" class="muted"></span>
             </div>
           </div>
         </div>
-        <button id="toggleLog" class="btn small">Afficher le journal</button>
         <div id="logBox" class="card log-box" hidden>
           <h2>Journal</h2>
           <div id="logEntries" class="log-entries"></div>

--- a/styles.css
+++ b/styles.css
@@ -116,11 +116,10 @@ label input[type="text"], label input[type="url"], label select, input[type="num
 .now-meta .url{font-size:12px; color:var(--muted); word-break:break-all}
 
 .controls{display:flex; align-items:center; gap:10px; flex-wrap:wrap; margin:10px 0}
-.vol{display:flex; align-items:center; gap:10px}
 .muted{color:var(--muted); font-size:12px}
 
 .player-area{display:flex; gap:16px; flex-wrap:wrap}
-.player-area .player-card{flex:1 1 300px}
+.player-area .player-card{flex:1 1 300px; position:relative}
 .log-box{flex:1 1 200px; font-size:12px; max-height:150px; overflow:auto; overflow-wrap:anywhere}
 .log-box h2{margin:0 0 8px; font-size:14px}
 .log-box pre{white-space:pre-wrap}
@@ -139,6 +138,17 @@ label input[type="text"], label input[type="url"], label select, input[type="num
 .item .sub{font-size:12px; color:var(--muted)}
 .item .actions{display:flex; gap:6px}
 .badge{font-size:11px; padding:2px 8px; border-radius:999px; background:var(--primary); color:#fff}
+
+.log-badge{
+  position:absolute;
+  top:8px; right:8px;
+  width:16px; height:16px;
+  border-radius:50%;
+  background:var(--primary);
+  border:none; padding:0;
+  cursor:pointer;
+}
+.log-badge.on{background:#3b82f6}
 
 .manage-list .item .left{display:flex; align-items:center; gap:10px}
 
@@ -179,6 +189,12 @@ label input[type="text"], label input[type="url"], label select, input[type="num
 
 @media (max-width:560px){
   .grid{grid-template-columns:1fr}
+}
+
+@media (max-width:480px){
+  .slides{gap:10px}
+  .slide{padding:0 8px 64px}
+  .player-area{gap:8px}
 }
 
 .compact .item{padding:10px}


### PR DESCRIPTION
## Résumé
- Bouton de journal déplacé dans le lecteur sous forme de pastille colorée
- Remplacement du minuteur sommeil par une réglette automatique "Sleep"
- Suppression de la réglette de volume et ajustement mobile des panneaux

## Tests
- `npm test` *(échec : Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6bd98690c8322a900a2b549df5f9a