### PR TITLE
Déplace les options du lecteur vers le panneau avancé

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,8 +53,6 @@
           </div>
 
           <div class="extras">
-            <label class="mui-switch">Reprendre automatiquement le dernier flux <input type="checkbox" id="autoResume"></label>
-            <label class="mui-switch">Afficher titre sur l’écran verrouillé <input type="checkbox" id="showLockInfo"></label>
             <div class="sleep">
               <label for="sleepMinutes">Sleep</label>
               <input id="sleepMinutes" type="range" min="0" max="90" step="5" value="0" list="sleepMarks" />
@@ -155,6 +153,8 @@
         <h2>Interface</h2>
         <label class="mui-switch"><input type="checkbox" id="compactList"> Liste compacte</label>
         <label class="mui-switch"><input type="checkbox" id="haptics"> Retour haptique (si dispo)</label>
+        <label class="mui-switch"><input type="checkbox" id="autoResume"> Reprendre automatiquement le dernier flux</label>
+        <label class="mui-switch"><input type="checkbox" id="showLockInfo"> Afficher titre sur l’écran verrouillé</label>
       </div>
 
       <div class="card">


### PR DESCRIPTION
### Résumé
- déplace les commutateurs d'auto-reprise et de titre verrouillé vers le panneau Options avancées

### Tests
- `npm test` *(script manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68a731783dc08322b3755337223fd091