### PR TITLE
Ajouter un script de mise à jour

### DIFF
--- a/update
+++ b/update
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Déterminer le répertoire racine du dépôt.
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cd "$ROOT_DIR"
+
+echo "Mise à jour du dépôt..."
+git pull
+
+echo "Installation des dépendances et build du frontend..."
+cd "$ROOT_DIR/frontend"
+npm install
+npm run build


### PR DESCRIPTION
## Résumé
- ajoute un script `update` à la racine
- automatise git pull, installation des dépendances et build du frontend

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69236f223cc88322a4c76b3c4822be0b)